### PR TITLE
Missing using Xpand.XAF.Modules.Reactive.Services;

### DIFF
--- a/Demos/XVideoRental/XVideoRental.Module.Win/XVideoRental.Module.Win.csproj
+++ b/Demos/XVideoRental/XVideoRental.Module.Win/XVideoRental.Module.Win.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="fasterflect" Version="2.1.3" />
     <PackageReference Include="System.Reactive" Version="4.2.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Xpand.Extensions" Version="0.0.8.4" />
     <PackageReference Include="Xpand.VersionConverter" Version="1.0.36" />
     <PackageReference Include="DevExpress.Charts.Core" Version="19.2.3" />
     <PackageReference Include="DevExpress.ExpressApp.Chart.Win" Version="19.2.3" />

--- a/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Web/Xpand.ExpressApp.ExcelImporter.Web.csproj
+++ b/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Web/Xpand.ExpressApp.ExcelImporter.Web.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="DevExpress.RichEdit.Core" Version="19.2.3" />
     <PackageReference Include="DevExpress.Web" Version="19.2.3" />
     <PackageReference Include="DevExpress.Xpo" Version="19.2.3" />
+    <PackageReference Include="Xpand.Extensions" Version="0.0.8.4" />
     <PackageReference Include="Xpand.Extensions.XAF" Version="0.0.7.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Win/ExcelImporterWinModule.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Win/ExcelImporterWinModule.cs
@@ -15,6 +15,7 @@ using Xpand.ExpressApp.ExcelImporter.Win.BusinessObjects;
 using Xpand.ExpressApp.ExcelImporter.Win.Services;
 using Xpand.ExpressApp.Validation.Win;
 using Xpand.ExpressApp.Win.SystemModule;
+using Xpand.Extensions.Reactive.Transform;
 using Xpand.Persistent.Base.General;
 using Xpand.XAF.Modules.Reactive;
 using Xpand.XAF.Modules.Reactive.Extensions;

--- a/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Win/Services/AutoImportService.cs
+++ b/Xpand/Xpand.ExpressApp.Modules/ExcelImporter.Win/Services/AutoImportService.cs
@@ -14,6 +14,7 @@ using JetBrains.Annotations;
 using Xpand.ExpressApp.ExcelImporter.BusinessObjects;
 using Xpand.ExpressApp.ExcelImporter.Services;
 using Xpand.ExpressApp.ExcelImporter.Win.BusinessObjects;
+using Xpand.Extensions.Reactive.Transform;
 using Xpand.XAF.Modules.Reactive.Extensions;
 using Xpand.XAF.Modules.Reactive.Services;
 


### PR DESCRIPTION
using Xpand.XAF.Modules.Reactive.Services; was missing from two files causing a failure to build in Xpand.ExpressApp.ExcelImporter.Win